### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,14 +16,15 @@ jobs:
     strategy:
       matrix:
         java-version: [ 8, 11 ]
+        distro: [ 'zulu', 'temurin' ]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK ${{ matrix.java-version }} ${{ matrix.distro }}
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: 'adopt'
+        distribution: ${{ matrix.distro }}
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Temurin began Aug 2021 with LTS versions.

Signed-off-by: Carl Dea <carldea@gmail.com>